### PR TITLE
feat(proxy): modernize VPC Lattice external connectivity

### DIFF
--- a/.cfnlintrc
+++ b/.cfnlintrc
@@ -1,10 +1,12 @@
 # cfn-lint configuration.
 #
-# E3014 and E3021 are false positives on guidance-stack.yml: the
-# AWS::ApplicationAutoScaling::ScalableTarget uses an Fn::Join/GetAtt ResourceId
-# under the AWS::LanguageExtensions transform, which cfn-lint's dependency analysis
-# misreads (it cannot fully expand the transform locally). The template deploys
-# cleanly (verified via change sets), so these rules are disabled repo-wide.
+# E1019, E3014, and E3021 are false positives on guidance-stack.yml:
+# AWS::LanguageExtensions expands Fn::ForEach iterator variables and generated
+# resource names before deployment, but cfn-lint evaluates parts of the raw
+# template before expansion. E1019 misreads iterator variables such as SubnetType,
+# AvailabilityZone, and EndpointType as missing parameters; E3014/E3021 misread
+# the Application Auto Scaling ResourceId dependency. The template deploys cleanly
+# (verified via change sets), so these rules are disabled repo-wide.
 #
 # W1030 fires because cfn-lint resolves the VpcCidr parameter default and checks the
 # parameter value against an 'ipv4-network' format; the parameter's AllowedPattern
@@ -14,6 +16,7 @@ templates:
   - testing/*.yml
 
 ignore_checks:
+  - E1019
   - E3014
   - E3021
   - W1030

--- a/.commitlintrc.yaml
+++ b/.commitlintrc.yaml
@@ -1,0 +1,31 @@
+# .commitlintrc.yaml
+extends:
+  - "@commitlint/config-conventional"
+
+rules:
+  # --- header format ---
+  header-max-length: [2, always, 72]
+  subject-case: [2, always, sentence-case]
+  type-enum:
+    [2, always,
+      [
+        feat,
+        fix,
+        docs,
+        refactor,
+        perf,
+        test,
+        ci,
+        chore,
+        revert
+      ]
+    ]
+
+  # --- scope pattern ---
+  scope-case: [2, always, kebab-case]
+  scope-empty: [0]
+  type-case: [2, always, lower-case]
+  body-leading-blank: [2, always]
+  body-max-line-length: [2, always, 140]
+  footer-leading-blank: [2, always]
+  signed-off-by: [0]

--- a/.commitlintrc.yaml
+++ b/.commitlintrc.yaml
@@ -5,7 +5,9 @@ extends:
 rules:
   # --- header format ---
   header-max-length: [2, always, 72]
-  subject-case: [2, always, sentence-case]
+  # Keep conventional commit subjects lowercase without forcing acronyms such as
+  # VPC, IAM, or AWS to lowercase.
+  subject-case: [2, never, [sentence-case, start-case, pascal-case, upper-case]]
   type-enum:
     [2, always,
       [

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,19 @@
+---
+# Dependabot configuration
+# https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+# Dependabot options reference:
+# https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference
+
+version: 2
+updates:
+  # GitHub Actions
+  - package-ecosystem: github-actions
+    directory: /
+    commit-message:
+      prefix: "ci(deps): "
+    schedule:
+      interval: weekly
+      day: friday
+      time: "00:00"
+      timezone: UTC
+    open-pull-requests-limit: 10

--- a/.github/scripts/validate-envoy.sh
+++ b/.github/scripts/validate-envoy.sh
@@ -10,7 +10,7 @@
 
 set -euo pipefail
 
-cd "$(dirname "$0")/../.."   # repo root
+cd "$(dirname "$0")/../.." # repo root
 
 DOCKERFILE=proxies/envoy/Dockerfile
 CONF=proxies/envoy/envoy.yaml

--- a/.github/scripts/validate-nginx.sh
+++ b/.github/scripts/validate-nginx.sh
@@ -7,7 +7,7 @@
 
 set -euo pipefail
 
-cd "$(dirname "$0")/../.."   # repo root
+cd "$(dirname "$0")/../.." # repo root
 
 DOCKERFILE=proxies/nginx/Dockerfile
 CONF=proxies/nginx/nginx.conf

--- a/.github/workflows/maintainer_workflows.yml
+++ b/.github/workflows/maintainer_workflows.yml
@@ -1,5 +1,6 @@
 # Workflows managed by aws-solutions-library-samples maintainers
 name: Maintainer Workflows
+
 on:
   # Triggers the workflow on push or pull request events but only for the "main" branch
   push:
@@ -8,12 +9,22 @@ on:
     branches: [ "main" ]
     types: [opened, reopened, edited]
 
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   CheckSolutionId:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Run solutionid validator
         run: |
+          set -euo pipefail
           chmod u+x ./.github/solutionid_validator.sh
-          ./.github/solutionid_validator.sh ${{ vars.SOLUTIONID }}
+          ./.github/solutionid_validator.sh "${{ vars.SOLUTIONID }}"

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -10,80 +10,110 @@ on:
     branches: [main]
   pull_request:
 
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   cfn-lint:
     name: cfn-lint (templates)
     runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
-      - run: pip install cfn-lint
+          cache: pip
+      - run: pip install cfn-lint==1.51.4
       - name: Lint CloudFormation
         run: cfn-lint   # uses .cfnlintrc (templates + ignore_checks)
 
   cfn-security:
     name: CloudFormation security (checkov + cfn-nag)
     runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
-      - run: pip install checkov
+          cache: pip
+      - run: pip install checkov==3.2.533
       - name: Checkov (testing/ templates)
         run: checkov --config-file .checkov.yml
       # cfn-nag scans the raw template; like checkov it cannot expand the
       # AWS::LanguageExtensions transform, so it is scoped to the plain testing/
       # templates. The main stack is covered by cfn-lint.
       - name: cfn-nag (testing/ templates)
-        uses: stelligent/cfn_nag@master
-        with:
-          input_path: testing
-          extra_args: --fail-on-warnings
+        run: |
+          set -euo pipefail
+          gem install cfn-nag -v 0.8.10
+          cfn_nag_scan --input-path testing --fail-on-warnings
 
   dockerfiles:
     name: hadolint (Dockerfiles)
     runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Lint NGINX Dockerfile
-        uses: hadolint/hadolint-action@v3.1.0
+        uses: hadolint/hadolint-action@v3.3.0
         with:
           dockerfile: proxies/nginx/Dockerfile
       - name: Lint Envoy Dockerfile
-        uses: hadolint/hadolint-action@v3.1.0
+        uses: hadolint/hadolint-action@v3.3.0
         with:
           dockerfile: proxies/envoy/Dockerfile
 
   shell:
     name: shellcheck (scripts)
     runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: ShellCheck
-        uses: ludeeus/action-shellcheck@master
+        uses: ludeeus/action-shellcheck@2.0.0
         with:
           scandir: "."
 
   proxy-configs:
     name: Proxy config validation (nginx -t / envoy validate)
     runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Validate NGINX config
-        run: ./.github/scripts/validate-nginx.sh
+        run: |
+          set -euo pipefail
+          ./.github/scripts/validate-nginx.sh
       - name: Validate Envoy config
-        run: ./.github/scripts/validate-envoy.sh
+        run: |
+          set -euo pipefail
+          ./.github/scripts/validate-envoy.sh
 
   markdown-links:
     name: Markdown link check
     runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Check links
-        uses: gaurav-nelson/github-action-markdown-link-check@v1
+        uses: tcort/github-action-markdown-link-check@v1
         with:
           use-quiet-mode: "yes"
           config-file: .github/markdown-link-check.json

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,58 +1,112 @@
-# Pre-commit hooks for local validation. Mirrors the CI workflow
-# (.github/workflows/validation.yml) so issues are caught before pushing.
+---
+# Pre-commit hooks configuration
+# Install:      pre-commit install
+# Update:       pre-commit autoupdate
+# Run manually: pre-commit run --all-files
 #
-# Setup:
-#   pip install pre-commit
-#   pre-commit install
-# Run on demand against all files:
-#   pre-commit run --all-files
+# Mirrors the CI workflow (.github/workflows/validation.yml) where practical so
+# issues are caught locally before pushing. cfn-nag is not included here because
+# it brings a Ruby/Docker dependency and already runs in CI.
 #
-# Note: hadolint and the Envoy/NGINX config checks run via Docker, so Docker must
-# be available locally for those hooks. cfn-nag is not included here (Ruby/Docker
-# dependency); it runs in CI only.
+# Ordering principle: cheap secret/file hygiene first, then read-only linters and
+# repo-specific validators.
+
+default_install_hook_types: [pre-commit, commit-msg]
 
 repos:
-  # ---- CloudFormation linting ----
+  # Secret and file hygiene checks from pre-commit's stock hooks
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v6.0.0
+    hooks:
+      - id: check-yaml
+        name: Check YAML syntax
+        # CloudFormation intrinsics and AWS::LanguageExtensions are handled by
+        # cfn-lint.
+        exclude: ^(guidance-stack\.yml|testing/.*\.yml)$
+      - id: check-json
+        name: Check JSON syntax
+      - id: check-merge-conflict
+        name: Check for merge conflict markers
+      - id: detect-private-key
+        name: Detect Private Keys
+      - id: detect-aws-credentials
+        name: Detect AWS Credentials
+        args: [--allow-missing-credentials]
+      - id: check-added-large-files
+        name: Check added large files
+      - id: check-executables-have-shebangs
+        name: Check executables have shebangs
+      - id: check-symlinks
+        name: Check symlinks
+
+  # CloudFormation linting
   - repo: https://github.com/aws-cloudformation/cfn-lint
-    rev: v1.46.0
+    rev: v1.51.4
     hooks:
       - id: cfn-lint
-        files: (guidance-stack\.yml|testing/.*\.yml)$
+        name: cfn-lint (CloudFormation templates)
+        files: ^(guidance-stack\.yml|testing/.*\.yml)$
 
-  # ---- CloudFormation security scanning (testing/ templates) ----
+  # CloudFormation security scanning (testing/ templates)
   - repo: https://github.com/bridgecrewio/checkov
-    rev: 3.2.500
+    rev: 3.2.533
     hooks:
       - id: checkov
-        args: ["--config-file", ".checkov.yml"]
+        name: Checkov (CloudFormation security)
+        args: [--config-file, .checkov.yml]
         pass_filenames: false
 
-  # ---- Dockerfile linting ----
-  - repo: https://github.com/hadolint/hadolint
-    rev: v2.13.1
+  # Spell-check documentation
+  - repo: https://github.com/codespell-project/codespell
+    rev: v2.4.2
     hooks:
-      - id: hadolint
-        files: proxies/.*/Dockerfile$
+      - id: codespell
+        name: Codespell (typos)
+        files: \.md$
 
-  # ---- Shell script linting ----
-  - repo: https://github.com/koalaman/shellcheck-precommit
-    rev: v0.10.0
+  # Enforce conventional-commit messages from .commitlintrc.yaml (commit-msg)
+  - repo: https://github.com/alessandrojcm/commitlint-pre-commit-hook
+    rev: v9.25.0
+    hooks:
+      - id: commitlint
+        name: Commitlint
+        stages: [commit-msg]
+
+  # Lint GitHub Actions workflows
+  - repo: https://github.com/rhysd/actionlint
+    rev: v1.7.12
+    hooks:
+      - id: actionlint
+        name: Actionlint (GitHub Actions)
+
+  # Static analysis for shell scripts
+  - repo: https://github.com/shellcheck-py/shellcheck-py
+    rev: v0.11.0.1
     hooks:
       - id: shellcheck
+        name: ShellCheck (shell linter)
         files: \.sh$
+        args: [--severity=warning]
 
-  # ---- Local hooks: proxy config validation via the pinned engine images ----
+  # Local hooks: proxy config validation via the pinned engine images
   - repo: local
     hooks:
+      - id: hadolint
+        name: Hadolint (Dockerfiles)
+        language: system
+        entry: hadolint
+        files: ^proxies/.*/Dockerfile$
       - id: nginx-config-test
         name: nginx -t (validate nginx.conf in the shipped image)
         language: script
         entry: .github/scripts/validate-nginx.sh
-        files: proxies/nginx/(nginx\.conf|Dockerfile)$
+        files: ^proxies/nginx/(nginx\.conf|Dockerfile)$
         pass_filenames: false
+        stages: [manual]
       - id: envoy-config-validate
         name: envoy --mode validate (validate envoy.yaml in the shipped image)
         language: script
         entry: .github/scripts/validate-envoy.sh
-        files: proxies/envoy/(envoy\.yaml|Dockerfile)$
+        files: ^proxies/envoy/(envoy\.yaml|Dockerfile)$
         pass_filenames: false
+        stages: [manual]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -71,6 +71,8 @@ repos:
       - id: commitlint
         name: Commitlint
         stages: [commit-msg]
+        additional_dependencies:
+          - "@commitlint/config-conventional"
 
   # Lint GitHub Actions workflows
   - repo: https://github.com/rhysd/actionlint

--- a/guidance-stack.yml
+++ b/guidance-stack.yml
@@ -3,20 +3,20 @@ Description: (SO9403) Guidance - External Connectivity to Amazon VPC Lattice
 Transform: 'AWS::LanguageExtensions'
 
 Parameters:
-  AllowedIPv4Block:
+  pAllowedIPv4Block:
     Description: IPv4 CIDR block for the allowed IP address range on the NLB
     Type: String
-  AllowedIPv6Block:
+  pAllowedIPv6Block:
     Description: IPv6 CIDR block for the allowed IP address range on the NLB
     Type: String
     Default: EMPTY
-  VpcCidr:
+  pVpcCidr:
     Type: String
     Default: 192.168.1.0/16
     Description: IPv4 CIDR block for the VPC
     AllowedPattern: "^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)(?:\\/(?:[0-9]|[1-2][0-9]|3[0-2]))$"
     ConstraintDescription: Must be a valid IPv4 CIDR block (e.g., 192.168.1.0/16)
-  ProxyEngine:
+  pProxyEngine:
     Type: String
     Default: nginx
     AllowedValues:
@@ -27,25 +27,25 @@ Parameters:
       into the CodeCommit repository at stack creation. NGINX is the simplest
       TLS-passthrough option; Envoy provides the same passthrough behavior on a
       more extensible data plane.
-  SourceRepoUrl:
+  pSourceRepoUrl:
     Type: String
     Default: https://github.com/aws-solutions-library-samples/guidance-for-external-connectivity-amazon-vpc-lattice.git
     Description: >-
       Git URL used ONCE at stack creation to seed the CodeCommit repository with the selected proxy source. Point this at your own fork to bootstrap from custom code.
-  SourceRepoBranch:
+  pSourceRepoBranch:
     Type: String
     Default: main
     Description: Branch of SourceRepoUrl to seed the CodeCommit repository from.
 
 Conditions:
-  Ipv6Provided: !Not [!Equals [!Ref AllowedIPv6Block, EMPTY]]
+  cIpv6Provided: !Not [!Equals [!Ref pAllowedIPv6Block, EMPTY]]
 
 Mappings:
   # Maps each logical subnet name to its index (0-8) into the nine /24 blocks that
   # !Cidr carves out of VpcCidr, giving every subnet a deterministic, non-overlapping
   # range. The same index selects the matching IPv6 /64 from the VPC's /56.
-  SubnetCIDR:
-    Position: 
+  mSubnetCIDR:
+    Position:
       PublicSubneta: 0
       PublicSubnetb: 1
       PublicSubnetc: 2
@@ -59,7 +59,7 @@ Mappings:
   # ServiceName (com.amazonaws.<region>.<suffix>) is assembled where the endpoints
   # are created. These are the endpoints Fargate needs to pull images, ship logs,
   # and support ECS Exec without a NAT gateway.
-  Endpoint:
+  mEndpoint:
     Type:
       ECRDKR: ecr.dkr
       ECRAPI: ecr.api
@@ -70,10 +70,10 @@ Mappings:
 
 Resources:
   # ---------- AMAZON VPC RESOURCES ----------
-  VPC:
+  rVPC:
     Type: AWS::EC2::VPC
     Properties:
-      CidrBlock: !Ref VpcCidr
+      CidrBlock: !Ref pVpcCidr
       EnableDnsSupport: true
       EnableDnsHostnames: true
       Tags:
@@ -83,20 +83,20 @@ Resources:
             - - vpc
               - !Ref AWS::StackName
 
-  IPv6CidrBlock:
+  rIPv6CidrBlock:
     Type: AWS::EC2::VPCCidrBlock
     Properties:
         AmazonProvidedIpv6CidrBlock: true
-        VpcId: !Ref VPC
+        VpcId: !Ref rVPC
 
-  InternetGateway:
+  rInternetGateway:
     Type: AWS::EC2::InternetGateway
 
-  InternetGatewayAttachment:
+  rInternetGatewayAttachment:
     Type: AWS::EC2::VPCGatewayAttachment
     Properties:
-      VpcId: !Ref VPC
-      InternetGatewayId: !Ref InternetGateway
+      VpcId: !Ref rVPC
+      InternetGatewayId: !Ref rInternetGateway
 
   # For::Each iteration: per subnet type (Public, Private, Endpoint) and AZ (3 AZs)
   # Resources to create: 9 subnets, 9 route tables, 9 route table associations - obtaining AZ affinity
@@ -114,14 +114,14 @@ Resources:
             # subnets evaluate !Select [0, VPC.Ipv6CidrBlocks]; otherwise the list is
             # empty and deployment fails with "Fn::Select cannot select nonexistent
             # value at index 0".
-            DependsOn: IPv6CidrBlock
+            DependsOn: rIPv6CidrBlock
             Properties:
-              VpcId: !Ref VPC
+              VpcId: !Ref rVPC
               AvailabilityZone: !Sub ${AWS::Region}${AvailabilityZone}
               # IPv4: split VpcCidr into 9 equal blocks and take this subnet's slot.
               # IPv6: split the VPC's Amazon-provided /56 into /64s and take the same slot.
-              CidrBlock: !Select [!FindInMap [SubnetCIDR, Position, 'Fn::Sub': '${SubnetType}Subnet${AvailabilityZone}'], !Cidr [!Ref VpcCidr, 9, 8 ]]
-              Ipv6CidrBlock: !Select [!FindInMap [SubnetCIDR, Position, 'Fn::Sub': '${SubnetType}Subnet${AvailabilityZone}'], !Cidr [!Select [0, !GetAtt VPC.Ipv6CidrBlocks], 9, 64 ]]
+              CidrBlock: !Select [!FindInMap [mSubnetCIDR, Position, 'Fn::Sub': '${SubnetType}Subnet${AvailabilityZone}'], !Cidr [!Ref pVpcCidr, 9, 8 ]]
+              Ipv6CidrBlock: !Select [!FindInMap [mSubnetCIDR, Position, 'Fn::Sub': '${SubnetType}Subnet${AvailabilityZone}'], !Cidr [!Select [0, !GetAtt rVPC.Ipv6CidrBlocks], 9, 64 ]]
               Tags:
                 - Key: Name
                   Value: !Join
@@ -132,8 +132,8 @@ Resources:
           '${SubnetType}RouteTable${AvailabilityZone}':
             Type: AWS::EC2::RouteTable
             Properties:
-              VpcId: !Ref VPC
-              Tags: 
+              VpcId: !Ref rVPC
+              Tags:
                 - Key: Name
                   Value: !Join
                     - '-'
@@ -142,7 +142,7 @@ Resources:
           # Route Table associations
           '${SubnetType}RouteTableAssociation${AvailabilityZone}':
             Type: AWS::EC2::SubnetRouteTableAssociation
-            Properties: 
+            Properties:
               RouteTableId: !Ref
                 'Fn::Sub': '${SubnetType}RouteTable${AvailabilityZone}'
               SubnetId: !Ref
@@ -155,22 +155,22 @@ Resources:
     - [a, b, c]
     - 'Ipv4Route${AvailabilityZone}':
         DependsOn:
-          - InternetGatewayAttachment
+          - rInternetGatewayAttachment
         Type: AWS::EC2::Route
         Properties:
           DestinationCidrBlock: 0.0.0.0/0
           RouteTableId: !Ref
             'Fn::Sub': 'PublicRouteTable${AvailabilityZone}'
-          GatewayId: !Ref InternetGateway
+          GatewayId: !Ref rInternetGateway
       'Ipv6Route${AvailabilityZone}':
         DependsOn:
-          - InternetGatewayAttachment
+          - rInternetGatewayAttachment
         Type: AWS::EC2::Route
         Properties:
           DestinationIpv6CidrBlock: ::/0
           RouteTableId: !Ref
             'Fn::Sub': 'PublicRouteTable${AvailabilityZone}'
-          GatewayId: !Ref InternetGateway
+          GatewayId: !Ref rInternetGateway
 
   # ---------- VPC ENDPOINTS ----------
   # For::Each iteration: per Endpoint Type
@@ -180,84 +180,84 @@ Resources:
     - [ECRDKR, ECRAPI, Logs, SSM, SSMMessages, EC2Messages]
     - 'InterfaceEndpoint${EndpointType}':
         Type: AWS::EC2::VPCEndpoint
-        Properties: 
+        Properties:
           PrivateDnsEnabled: true
-          SecurityGroupIds: 
-            - !Ref EndpointSecurityGroup
+          SecurityGroupIds:
+            - !Ref rEndpointSecurityGroup
           ServiceName: !Join
             - '.'
             - - com.amazonaws
               - !Sub ${AWS::Region}
-              - !FindInMap [Endpoint, Type, 'Fn::Sub': '${EndpointType}']
-          SubnetIds: 
+              - !FindInMap [mEndpoint, Type, 'Fn::Sub': '${EndpointType}']
+          SubnetIds:
             - !Ref EndpointSubneta
             - !Ref EndpointSubnetb
             - !Ref EndpointSubnetc
           VpcEndpointType: Interface
-          VpcId: !Ref VPC
+          VpcId: !Ref rVPC
 
   # ECR stores image layers in S3, so pulling images needs an S3 path. A gateway
   # endpoint (route-table based, no ENI/hourly cost) covers it without a NAT gateway.
-  S3GatewayEndpoint:
+  rS3GatewayEndpoint:
     Type: AWS::EC2::VPCEndpoint
-    Properties: 
-      RouteTableIds: 
+    Properties:
+      RouteTableIds:
         - !Ref PrivateRouteTablea
         - !Ref PrivateRouteTableb
         - !Ref PrivateRouteTablec
       ServiceName: !Sub com.amazonaws.${AWS::Region}.s3
       VpcEndpointType: Gateway
-      VpcId: !Ref VPC
+      VpcId: !Ref rVPC
 
   # ---------- SECURITY GROUPS ----------
   # Network Load Balancer
-  ProxyNLBSG:
+  rProxyNLBSG:
     Type: 'AWS::EC2::SecurityGroup'
     Properties:
-      VpcId: !Ref VPC
+      VpcId: !Ref rVPC
       GroupDescription: Proxy NLB Security Group
       Tags:
         - Key: Name
           Value: !Join
             - '-'
-            - - !Sub '${ProxyEngine}-nlb-sg'
+            - - !Sub '${pProxyEngine}-nlb-sg'
               - !Ref AWS::StackName
 
   # IPv4 Ingress rule (NLB) & Egress rule (TLS-only: port 443)
-  ProxyNLBSGIPv4IngressHTTPS:
+  rProxyNLBSGIPv4IngressHTTPS:
     Type: AWS::EC2::SecurityGroupIngress
     Properties:
-      GroupId: !Ref ProxyNLBSG
-      CidrIp: !Ref AllowedIPv4Block
+      GroupId: !Ref rProxyNLBSG
+      CidrIp: !Ref pAllowedIPv4Block
       IpProtocol: 'tcp'
       FromPort: 443
       ToPort: 443
 
-  ProxyNLBSGEgressHTTPS:
+  rProxyNLBSGEgressHTTPS:
     Type: AWS::EC2::SecurityGroupEgress
     Properties:
-      GroupId: !Ref ProxyNLBSG
-      DestinationSecurityGroupId: !Ref ProxyECSSG
+      GroupId: !Ref rProxyNLBSG
+      DestinationSecurityGroupId: !Ref rProxyECSSG
       IpProtocol: 'tcp'
       FromPort: 443
       ToPort: 443
 
   # IPv6 Ingress rule (NLB) - if provided
-  ProxyNLBSGIPv6IngressHTTPS:
+  rProxyNLBSGIPv6IngressHTTPS:
     Type: AWS::EC2::SecurityGroupIngress
-    Condition: Ipv6Provided
+    Condition: cIpv6Provided
     Properties:
-      GroupId: !Ref ProxyNLBSG
-      CidrIpv6: !Ref AllowedIPv6Block
+      GroupId: !Ref rProxyNLBSG
+      CidrIpv6: !Ref pAllowedIPv6Block
       IpProtocol: 'tcp'
       FromPort: 443
       ToPort: 443
 
   # ECS Cluster
-  ProxyECSSG:
+  rProxyECSSG:
     Type: 'AWS::EC2::SecurityGroup'
     Properties:
-      VpcId: !Ref VPC
+      VpcId: !Ref rVPC
       GroupDescription: Proxy (ECS) Security group
       SecurityGroupEgress:
         - CidrIp: 0.0.0.0/0
@@ -266,27 +266,27 @@ Resources:
         - Key: Name
           Value: !Join
             - '-'
-            - - !Sub '${ProxyEngine}-ecs-sg'
+            - - !Sub '${pProxyEngine}-ecs-sg'
               - !Ref AWS::StackName
-  
+
   # ECS ingress rule from the NLB (TLS-only: port 443)
-  ProxyECSSGIngressHTTPS:
+  rProxyECSSGIngressHTTPS:
     Type: AWS::EC2::SecurityGroupIngress
     Properties:
-      GroupId: !Ref ProxyECSSG
-      SourceSecurityGroupId: !Ref ProxyNLBSG
+      GroupId: !Ref rProxyECSSG
+      SourceSecurityGroupId: !Ref rProxyNLBSG
       IpProtocol: 'tcp'
       FromPort: 443
       ToPort: 443
 
   # VPC endpoints
-  EndpointSecurityGroup:
+  rEndpointSecurityGroup:
     Type: 'AWS::EC2::SecurityGroup'
     Properties:
-      VpcId: !Ref VPC
+      VpcId: !Ref rVPC
       GroupDescription: VPC Endpoint Security Group
       SecurityGroupIngress:
-        - CidrIp: !Ref VpcCidr
+        - CidrIp: !Ref pVpcCidr
           IpProtocol: 'tcp'
           FromPort: 443
           ToPort: 443
@@ -302,21 +302,21 @@ Resources:
               - !Ref AWS::StackName
 
   # ---------- NETWORK LOAD BALANCER ----------
-  ProxyNLB:
+  rProxyNLB:
     Type: 'AWS::ElasticLoadBalancingV2::LoadBalancer'
     Properties:
       IpAddressType: dualstack
       Scheme: internet-facing
       Type: network
-      SecurityGroups: 
-        - !Ref ProxyNLBSG
+      SecurityGroups:
+        - !Ref rProxyNLBSG
       Subnets:
         - !Ref PublicSubneta
         - !Ref PublicSubnetb
         - !Ref PublicSubnetc
 
   # Target Group: 443
-  ProxyNLBTGroupHTTPS:
+  rProxyNLBTGroupHTTPS:
     Type: 'AWS::ElasticLoadBalancingV2::TargetGroup'
     Properties:
       # Aggressive health checks (5s interval, 2s timeout, 3 checks) so an unhealthy
@@ -335,21 +335,21 @@ Resources:
           Value: true
       TargetType: ip
       UnhealthyThresholdCount: 3
-      VpcId: !Ref VPC
+      VpcId: !Ref rVPC
 
   # Listener: 443
-  ProxyNLBListenerHTTPS:
+  rProxyNLBListenerHTTPS:
     Type: 'AWS::ElasticLoadBalancingV2::Listener'
     Properties:
       DefaultActions:
-        - TargetGroupArn: !Ref ProxyNLBTGroupHTTPS
+        - TargetGroupArn: !Ref rProxyNLBTGroupHTTPS
           Type: forward
-      LoadBalancerArn: !Ref ProxyNLB
+      LoadBalancerArn: !Ref rProxyNLB
       Port: 443
       Protocol: TCP
 
   # ---------- AMAZON ECR REPOSITORY ----------
-  LatticeExternalConnectivityECRRepo:
+  rLatticeExternalConnectivityECRRepo:
     Type: AWS::ECR::Repository
     DeletionPolicy: Retain
     UpdateReplacePolicy: Retain
@@ -361,16 +361,16 @@ Resources:
   # Seeded once at stack creation from SourceRepoUrl with the selected proxy engine.
   # After deployment this is the user-editable source: a commit triggers the pipeline.
   # Retained on stack deletion so proxy customizations committed here are not lost.
-  ProxySourceRepo:
+  rProxySourceRepo:
     Type: AWS::CodeCommit::Repository
     DeletionPolicy: Retain
     UpdateReplacePolicy: Retain
     Properties:
-      RepositoryName: !Sub '${AWS::StackName}-${ProxyEngine}-source'
+      RepositoryName: !Sub '${AWS::StackName}-${pProxyEngine}-source'
       RepositoryDescription: !Sub 'Editable proxy source for ${AWS::StackName}. Commits trigger build and deploy.'
 
   # ---------- ECS CLUSTER ----------
-  ProxyCluster:
+  rProxyCluster:
     Type: 'AWS::ECS::Cluster'
     Properties:
       CapacityProviders:
@@ -383,15 +383,15 @@ Resources:
   # Initial task definition references the image built by the bootstrap stage
   # (tag: bootstrap). Subsequent deploys are driven by CodePipeline's ECS deploy
   # action, which registers new task-def revisions with immutable commit-based tags.
-  ProxyTask:
+  rProxyTask:
     DependsOn:
-      - ProxyBootstrapCustomResource
+      - rProxyBootstrapCustomResource
     Type: 'AWS::ECS::TaskDefinition'
     Properties:
-      ExecutionRoleArn: !GetAtt ProxyTaskExecRole.Arn
+      ExecutionRoleArn: !GetAtt rProxyTaskExecRole.Arn
       NetworkMode: awsvpc
       ContainerDefinitions:
-        - Image: !Sub "${AWS::AccountId}.dkr.ecr.${AWS::Region}.amazonaws.com/${LatticeExternalConnectivityECRRepo}:bootstrap"
+        - Image: !Sub "${AWS::AccountId}.dkr.ecr.${AWS::Region}.amazonaws.com/${rLatticeExternalConnectivityECRRepo}:bootstrap"
           Name: Proxy
           PortMappings:
             - ContainerPort: 443
@@ -400,7 +400,7 @@ Resources:
             LogDriver: awslogs
             Options:
               awslogs-region: !Ref 'AWS::Region'
-              awslogs-group: !Ref ProxyLogGroup
+              awslogs-group: !Ref rProxyLogGroup
               awslogs-stream-prefix: lattice-externalconnectivity
           Ulimits:
             # Raise the open-file-descriptor limit well above the default 1024 so the
@@ -417,15 +417,15 @@ Resources:
       RuntimePlatform:
         CpuArchitecture: ARM64
         OperatingSystemFamily: LINUX
-      TaskRoleArn: !GetAtt ProxyTaskRole.Arn
+      TaskRoleArn: !GetAtt rProxyTaskRole.Arn
 
   # ECS Service
-  ProxyService:
+  rProxyService:
     Type: 'AWS::ECS::Service'
     DependsOn:
-      - ProxyNLBListenerHTTPS
+      - rProxyNLBListenerHTTPS
     Properties:
-      Cluster: !Ref ProxyCluster
+      Cluster: !Ref rProxyCluster
       # Enables ECS Exec (interactive shell into a task) for debugging; relies on the
       # ssmmessages permissions granted to the task and task-execution roles below.
       EnableExecuteCommand: true
@@ -433,20 +433,20 @@ Resources:
       LoadBalancers:
         - ContainerName: Proxy
           ContainerPort: 443
-          TargetGroupArn: !Ref ProxyNLBTGroupHTTPS
+          TargetGroupArn: !Ref rProxyNLBTGroupHTTPS
       NetworkConfiguration:
         AwsvpcConfiguration:
           SecurityGroups:
-            - !Ref ProxyECSSG
+            - !Ref rProxyECSSG
           Subnets:
             - !Ref PrivateSubneta
             - !Ref PrivateSubnetb
             - !Ref PrivateSubnetc
       SchedulingStrategy: REPLICA
-      TaskDefinition: !Ref ProxyTask
+      TaskDefinition: !Ref rProxyTask
 
   # ECS Task Execution Role
-  ProxyTaskExecRole:
+  rProxyTaskExecRole:
     Type: 'AWS::IAM::Role'
     Properties:
       AssumeRolePolicyDocument:
@@ -470,7 +470,7 @@ Resources:
                   - 'ecr:BatchCheckLayerAvailability'
                   - 'ecr:GetDownloadUrlForLayer'
                   - 'ecr:BatchGetImage'
-                Resource: !Sub 'arn:${AWS::Partition}:ecr:${AWS::Region}:${AWS::AccountId}:repository/${LatticeExternalConnectivityECRRepo}'
+                Resource: !Sub 'arn:${AWS::Partition}:ecr:${AWS::Region}:${AWS::AccountId}:repository/${rLatticeExternalConnectivityECRRepo}'
               - Effect: Allow
                 Action: 'ecr:GetAuthorizationToken'
                 Resource: '*'
@@ -479,7 +479,7 @@ Resources:
                 Action:
                   - 'logs:CreateLogStream'
                   - 'logs:PutLogEvents'
-                Resource: !Sub 'arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/${ProxyCluster}:*'
+                Resource: !Sub 'arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/${rProxyCluster}:*'
               # ECS Exec (SSM messages) requires "*" - these actions do not support
               # resource-level scoping.
               - Effect: Allow
@@ -491,7 +491,7 @@ Resources:
                 Resource: '*'
 
   # ECS Task Role
-  ProxyTaskRole:
+  rProxyTaskRole:
     Type: 'AWS::IAM::Role'
     Properties:
       AssumeRolePolicyDocument:
@@ -519,34 +519,32 @@ Resources:
                 Resource: '*'
 
   # CloudWatch Log Group
-  ProxyLogGroup:
+  rProxyLogGroup:
     Type: 'AWS::Logs::LogGroup'
     Properties:
-      LogGroupName: !Sub '/${ProxyCluster}'
+      LogGroupName: !Sub '/${rProxyCluster}'
       RetentionInDays: 90
 
   # AutoScaling - Scalable Target
-  ProxyScalableTarget:
+  rProxyScalableTarget:
     Type: AWS::ApplicationAutoScaling::ScalableTarget
-    Properties: 
+    Properties:
       MaxCapacity: 9
       MinCapacity: 3
-      ResourceId: !Join ['',['service/',!Ref ProxyCluster,'/',!GetAtt ProxyService.Name]]
+      ResourceId: !Join ['',['service/',!Ref rProxyCluster,'/',!GetAtt rProxyService.Name]]
       # RoleARN is intentionally omitted: Application Auto Scaling uses the
       # AWSServiceRoleForApplicationAutoScaling_ECSService service-linked role
       # automatically (created on first use).
       ScalableDimension: 'ecs:service:DesiredCount'
       ServiceNamespace: 'ecs'
-      
+
   # AutoScaling Policy
-  ProxyScalingPolicy:
+  rProxyScalingPolicy:
     Type: AWS::ApplicationAutoScaling::ScalingPolicy
-    Properties: 
-      PolicyName: !Join ['',['scaling-policy-',!GetAtt ProxyService.Name]]
+    Properties:
+      PolicyName: !Join ['',['scaling-policy-',!GetAtt rProxyService.Name]]
       PolicyType: 'TargetTrackingScaling'
-      ResourceId: !Join ['',['service/',!Ref ProxyCluster,'/',!GetAtt ProxyService.Name]]
-      ScalableDimension: 'ecs:service:DesiredCount'
-      ScalingTargetId: !Ref ProxyScalableTarget
+      ScalingTargetId: !Ref rProxyScalableTarget
       TargetTrackingScalingPolicyConfiguration:
         TargetValue: 70.0
         ScaleInCooldown: 60
@@ -567,7 +565,7 @@ Resources:
   # the ECS service has something to start from on first creation.
 
   # ---------- PIPELINE ARTIFACT BUCKET ----------
-  PipelineArtifactBucket:
+  rPipelineArtifactBucket:
     Type: AWS::S3::Bucket
     DeletionPolicy: Retain
     UpdateReplacePolicy: Retain
@@ -585,7 +583,7 @@ Resources:
         Status: Enabled
 
   # ---------- BOOTSTRAP (seed CodeCommit + build initial image) ----------
-  BootstrapProjectRole:
+  rBootstrapProjectRole:
     Type: AWS::IAM::Role
     Properties:
       AssumeRolePolicyDocument:
@@ -606,8 +604,8 @@ Resources:
                   - logs:CreateLogStream
                   - logs:PutLogEvents
                 Resource:
-                  - !Sub 'arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/codebuild/${AWS::StackName}-${ProxyEngine}-bootstrap'
-                  - !Sub 'arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/codebuild/${AWS::StackName}-${ProxyEngine}-bootstrap:*'
+                  - !Sub 'arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/codebuild/${AWS::StackName}-${pProxyEngine}-bootstrap'
+                  - !Sub 'arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/codebuild/${AWS::StackName}-${pProxyEngine}-bootstrap:*'
         - PolicyName: CodeCommitSeed
           PolicyDocument:
             Version: '2012-10-17'
@@ -618,7 +616,7 @@ Resources:
                   - codecommit:GetBranch
                   - codecommit:GitPull
                   - codecommit:GitPush
-                Resource: !GetAtt ProxySourceRepo.Arn
+                Resource: !GetAtt rProxySourceRepo.Arn
         - PolicyName: ECRPush
           PolicyDocument:
             Version: '2012-10-17'
@@ -630,17 +628,17 @@ Resources:
                   - ecr:UploadLayerPart
                   - ecr:CompleteLayerUpload
                   - ecr:PutImage
-                Resource: !Sub 'arn:${AWS::Partition}:ecr:${AWS::Region}:${AWS::AccountId}:repository/${LatticeExternalConnectivityECRRepo}'
+                Resource: !Sub 'arn:${AWS::Partition}:ecr:${AWS::Region}:${AWS::AccountId}:repository/${rLatticeExternalConnectivityECRRepo}'
               - Effect: Allow
                 Action: ecr:GetAuthorizationToken
                 Resource: '*'
 
-  BootstrapProject:
+  rBootstrapProject:
     Type: AWS::CodeBuild::Project
     Properties:
-      Name: !Sub '${AWS::StackName}-${ProxyEngine}-bootstrap'
+      Name: !Sub '${AWS::StackName}-${pProxyEngine}-bootstrap'
       Description: 'Seed CodeCommit from SourceRepoUrl and build the initial proxy image'
-      ServiceRole: !GetAtt BootstrapProjectRole.Arn
+      ServiceRole: !GetAtt rBootstrapProjectRole.Arn
       Artifacts:
         Type: NO_ARTIFACTS
       Environment:
@@ -650,19 +648,19 @@ Resources:
         PrivilegedMode: true
         EnvironmentVariables:
           - Name: ECR_REPOSITORY
-            Value: !Ref LatticeExternalConnectivityECRRepo
+            Value: !Ref rLatticeExternalConnectivityECRRepo
           - Name: AWS_ACCOUNT_ID
             Value: !Ref 'AWS::AccountId'
           - Name: CC_REPO_NAME
-            Value: !GetAtt ProxySourceRepo.Name
+            Value: !GetAtt rProxySourceRepo.Name
           - Name: CC_BRANCH
-            Value: !Ref SourceRepoBranch
+            Value: !Ref pSourceRepoBranch
           - Name: SOURCE_REPO_URL
-            Value: !Ref SourceRepoUrl
+            Value: !Ref pSourceRepoUrl
           - Name: SOURCE_REPO_BRANCH
-            Value: !Ref SourceRepoBranch
+            Value: !Ref pSourceRepoBranch
           - Name: PROXY_ENGINE
-            Value: !Ref ProxyEngine
+            Value: !Ref pProxyEngine
       Source:
         Type: NO_SOURCE
         BuildSpec: |
@@ -721,7 +719,7 @@ Resources:
 
   # Lambda-backed custom resource: runs the bootstrap build on stack create and waits
   # until the ':bootstrap' image exists in ECR before the ECS service is created.
-  BootstrapLambdaRole:
+  rBootstrapLambdaRole:
     Type: AWS::IAM::Role
     Properties:
       AssumeRolePolicyDocument:
@@ -742,14 +740,14 @@ Resources:
                 Action:
                   - codebuild:StartBuild
                   - codebuild:BatchGetBuilds
-                Resource: !GetAtt BootstrapProject.Arn
+                Resource: !GetAtt rBootstrapProject.Arn
 
-  BootstrapLambda:
+  rBootstrapLambda:
     Type: AWS::Lambda::Function
     Properties:
       Handler: index.handler
-      Role: !GetAtt BootstrapLambdaRole.Arn
-      Runtime: python3.13
+      Role: !GetAtt rBootstrapLambdaRole.Arn
+      Runtime: python3.12
       Timeout: 900
       Code:
         ZipFile: |
@@ -797,16 +795,16 @@ Resources:
                   logger.exception('Bootstrap failed')
                   cfnresponse.send(event, context, cfnresponse.FAILED, {'Error': str(e)}, physical_id)
 
-  ProxyBootstrapCustomResource:
+  rProxyBootstrapCustomResource:
     Type: Custom::ProxyBootstrap
     DependsOn:
-      - ProxySourceRepo
+      - rProxySourceRepo
     Properties:
-      ServiceToken: !GetAtt BootstrapLambda.Arn
-      ProjectName: !Ref BootstrapProject
+      ServiceToken: !GetAtt rBootstrapLambda.Arn
+      ProjectName: !Ref rBootstrapProject
 
   # ---------- IMAGE BUILD (pipeline build stage) ----------
-  ImageBuildProjectRole:
+  rImageBuildProjectRole:
     Type: AWS::IAM::Role
     Properties:
       AssumeRolePolicyDocument:
@@ -827,8 +825,8 @@ Resources:
                   - logs:CreateLogStream
                   - logs:PutLogEvents
                 Resource:
-                  - !Sub 'arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/codebuild/${AWS::StackName}-${ProxyEngine}-image-build'
-                  - !Sub 'arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/codebuild/${AWS::StackName}-${ProxyEngine}-image-build:*'
+                  - !Sub 'arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/codebuild/${AWS::StackName}-${pProxyEngine}-image-build'
+                  - !Sub 'arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/codebuild/${AWS::StackName}-${pProxyEngine}-image-build:*'
         - PolicyName: ECRPush
           PolicyDocument:
             Version: '2012-10-17'
@@ -840,7 +838,7 @@ Resources:
                   - ecr:UploadLayerPart
                   - ecr:CompleteLayerUpload
                   - ecr:PutImage
-                Resource: !Sub 'arn:${AWS::Partition}:ecr:${AWS::Region}:${AWS::AccountId}:repository/${LatticeExternalConnectivityECRRepo}'
+                Resource: !Sub 'arn:${AWS::Partition}:ecr:${AWS::Region}:${AWS::AccountId}:repository/${rLatticeExternalConnectivityECRRepo}'
               - Effect: Allow
                 Action: ecr:GetAuthorizationToken
                 Resource: '*'
@@ -853,14 +851,14 @@ Resources:
                   - s3:GetObject
                   - s3:GetObjectVersion
                   - s3:PutObject
-                Resource: !Sub '${PipelineArtifactBucket.Arn}/*'
+                Resource: !Sub '${rPipelineArtifactBucket.Arn}/*'
 
-  ImageBuildProject:
+  rImageBuildProject:
     Type: AWS::CodeBuild::Project
     Properties:
-      Name: !Sub '${AWS::StackName}-${ProxyEngine}-image-build'
+      Name: !Sub '${AWS::StackName}-${pProxyEngine}-image-build'
       Description: 'Build and push the proxy image from CodeCommit source (pipeline build stage)'
-      ServiceRole: !GetAtt ImageBuildProjectRole.Arn
+      ServiceRole: !GetAtt rImageBuildProjectRole.Arn
       Artifacts:
         Type: CODEPIPELINE
       Environment:
@@ -870,7 +868,7 @@ Resources:
         PrivilegedMode: true
         EnvironmentVariables:
           - Name: ECR_REPOSITORY
-            Value: !Ref LatticeExternalConnectivityECRRepo
+            Value: !Ref rLatticeExternalConnectivityECRRepo
           - Name: AWS_ACCOUNT_ID
             Value: !Ref 'AWS::AccountId'
           - Name: CONTAINER_NAME
@@ -881,7 +879,7 @@ Resources:
       TimeoutInMinutes: 15
 
   # ---------- CODEPIPELINE ----------
-  PipelineRole:
+  rPipelineRole:
     Type: AWS::IAM::Role
     Properties:
       AssumeRolePolicyDocument:
@@ -903,8 +901,8 @@ Resources:
                   - s3:PutObject
                   - s3:GetBucketVersioning
                 Resource:
-                  - !GetAtt PipelineArtifactBucket.Arn
-                  - !Sub '${PipelineArtifactBucket.Arn}/*'
+                  - !GetAtt rPipelineArtifactBucket.Arn
+                  - !Sub '${rPipelineArtifactBucket.Arn}/*'
               - Effect: Allow
                 Action:
                   - codecommit:GetBranch
@@ -913,12 +911,12 @@ Resources:
                   - codecommit:UploadArchive
                   - codecommit:GetUploadArchiveStatus
                   - codecommit:CancelUploadArchive
-                Resource: !GetAtt ProxySourceRepo.Arn
+                Resource: !GetAtt rProxySourceRepo.Arn
               - Effect: Allow
                 Action:
                   - codebuild:StartBuild
                   - codebuild:BatchGetBuilds
-                Resource: !GetAtt ImageBuildProject.Arn
+                Resource: !GetAtt rImageBuildProject.Arn
               - Effect: Allow
                 Action:
                   - ecs:DescribeServices
@@ -931,19 +929,19 @@ Resources:
               - Effect: Allow
                 Action: iam:PassRole
                 Resource:
-                  - !GetAtt ProxyTaskExecRole.Arn
-                  - !GetAtt ProxyTaskRole.Arn
+                  - !GetAtt rProxyTaskExecRole.Arn
+                  - !GetAtt rProxyTaskRole.Arn
                 Condition:
                   StringEqualsIfExists:
                     iam:PassedToService: ecs-tasks.amazonaws.com
 
-  ProxyPipeline:
+  rProxyPipeline:
     Type: AWS::CodePipeline::Pipeline
     Properties:
-      RoleArn: !GetAtt PipelineRole.Arn
+      RoleArn: !GetAtt rPipelineRole.Arn
       ArtifactStore:
         Type: S3
-        Location: !Ref PipelineArtifactBucket
+        Location: !Ref rPipelineArtifactBucket
       Stages:
         - Name: Source
           Actions:
@@ -954,8 +952,8 @@ Resources:
                 Provider: CodeCommit
                 Version: '1'
               Configuration:
-                RepositoryName: !GetAtt ProxySourceRepo.Name
-                BranchName: !Ref SourceRepoBranch
+                RepositoryName: !GetAtt rProxySourceRepo.Name
+                BranchName: !Ref pSourceRepoBranch
                 # Polling disabled on purpose: the PipelineTriggerRule (EventBridge)
                 # starts the pipeline on each commit, which is faster than polling.
                 PollForSourceChanges: 'false'
@@ -970,7 +968,7 @@ Resources:
                 Provider: CodeBuild
                 Version: '1'
               Configuration:
-                ProjectName: !Ref ImageBuildProject
+                ProjectName: !Ref rImageBuildProject
               InputArtifacts:
                 - Name: SourceOutput
               OutputArtifacts:
@@ -984,14 +982,14 @@ Resources:
                 Provider: ECS
                 Version: '1'
               Configuration:
-                ClusterName: !Ref ProxyCluster
-                ServiceName: !GetAtt ProxyService.Name
+                ClusterName: !Ref rProxyCluster
+                ServiceName: !GetAtt rProxyService.Name
                 FileName: imagedefinitions.json
               InputArtifacts:
                 - Name: BuildOutput
 
   # EventBridge rule: trigger the pipeline on commits to the tracked branch.
-  PipelineTriggerRole:
+  rPipelineTriggerRole:
     Type: AWS::IAM::Role
     Properties:
       AssumeRolePolicyDocument:
@@ -1008,9 +1006,9 @@ Resources:
             Statement:
               - Effect: Allow
                 Action: codepipeline:StartPipelineExecution
-                Resource: !Sub 'arn:${AWS::Partition}:codepipeline:${AWS::Region}:${AWS::AccountId}:${ProxyPipeline}'
+                Resource: !Sub 'arn:${AWS::Partition}:codepipeline:${AWS::Region}:${AWS::AccountId}:${rProxyPipeline}'
 
-  PipelineTriggerRule:
+  rPipelineTriggerRule:
     Type: AWS::Events::Rule
     Properties:
       Description: !Sub 'Trigger ${AWS::StackName} proxy pipeline on CodeCommit commits'
@@ -1020,7 +1018,7 @@ Resources:
         detail-type:
           - CodeCommit Repository State Change
         resources:
-          - !GetAtt ProxySourceRepo.Arn
+          - !GetAtt rProxySourceRepo.Arn
         detail:
           event:
             - referenceCreated
@@ -1028,31 +1026,40 @@ Resources:
           referenceType:
             - branch
           referenceName:
-            - !Ref SourceRepoBranch
+            - !Ref pSourceRepoBranch
       Targets:
-        - Arn: !Sub 'arn:${AWS::Partition}:codepipeline:${AWS::Region}:${AWS::AccountId}:${ProxyPipeline}'
+        - Arn: !Sub 'arn:${AWS::Partition}:codepipeline:${AWS::Region}:${AWS::AccountId}:${rProxyPipeline}'
           Id: ProxyPipeline
-          RoleArn: !GetAtt PipelineTriggerRole.Arn
+          RoleArn: !GetAtt rPipelineTriggerRole.Arn
 
 Outputs:
-  VpcId:
+  oVpcId:
     Description: Ingress VPC ID
-    Value: !Ref VPC
-  NLBDomainName:
+    Value: !Ref rVPC
+  oNLBDomainName:
     Description: NLB Domain Name
-    Value: !GetAtt ProxyNLB.DNSName
-  NLBHostedZoneId:
+    Value: !GetAtt rProxyNLB.DNSName
+  oNLBHostedZoneId:
     Description: NLB Hosted Zone ID
-    Value: !GetAtt ProxyNLB.CanonicalHostedZoneID
-  ProxySourceRepoCloneUrlHttp:
+    Value: !GetAtt rProxyNLB.CanonicalHostedZoneID
+  oProxySourceRepoCloneUrlHttp:
     Description: HTTPS clone URL for the editable proxy source (CodeCommit). Commits trigger the pipeline.
-    Value: !GetAtt ProxySourceRepo.CloneUrlHttp
-  ProxySourceRepoName:
+    Value: !GetAtt rProxySourceRepo.CloneUrlHttp
+  oProxySourceRepoName:
     Description: CodeCommit repository name for the proxy source
-    Value: !GetAtt ProxySourceRepo.Name
-  ProxyPipelineName:
+    Value: !GetAtt rProxySourceRepo.Name
+  oProxyPipelineName:
     Description: CodePipeline that builds and deploys proxy changes
-    Value: !Ref ProxyPipeline
-  ECRRepositoryName:
+    Value: !Ref rProxyPipeline
+  oECRRepositoryName:
     Description: ECR repository holding the proxy images
-    Value: !Ref LatticeExternalConnectivityECRRepo
+    Value: !Ref rLatticeExternalConnectivityECRRepo
+  oProxyTaskDefinitionArn:
+    Description: Proxy ECS Task Definition ARN
+    Value: !Ref rProxyTask
+  oProxyLogGroupName:
+    Description: Proxy CloudWatch Log Group Name
+    Value: !Ref rProxyLogGroup
+  oProxyScalingPolicyArn:
+    Description: Proxy Application Auto Scaling Policy ARN
+    Value: !Ref rProxyScalingPolicy

--- a/testing/test-endpoint.sh
+++ b/testing/test-endpoint.sh
@@ -34,13 +34,30 @@ PROFILE=""
 
 while [ $# -gt 0 ]; do
   case "$1" in
-    --sign) SIGN="true"; shift ;;
-    --region) REGION="${2:-}"; shift 2 ;;
-    --profile) PROFILE="${2:-}"; shift 2 ;;
-    -h|--help)
-      grep '^#' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
-    -*) echo "Unknown option: $1" >&2; exit 1 ;;
-    *) ENDPOINT="$1"; shift ;;
+    --sign)
+      SIGN="true"
+      shift
+      ;;
+    --region)
+      REGION="${2:-}"
+      shift 2
+      ;;
+    --profile)
+      PROFILE="${2:-}"
+      shift 2
+      ;;
+    -h | --help)
+      grep '^#' "$0" | sed 's/^# \{0,1\}//'
+      exit 0
+      ;;
+    -*)
+      echo "Unknown option: $1" >&2
+      exit 1
+      ;;
+    *)
+      ENDPOINT="$1"
+      shift
+      ;;
   esac
 done
 
@@ -64,7 +81,7 @@ fi
 
 # Resolve credentials: profile/credential chain first, then existing env vars.
 if [ -n "$PROFILE" ]; then
-  creds=$(aws configure export-credentials --format process --profile "$PROFILE" 2>/dev/null || true)
+  creds=$(aws configure export-credentials --format process --profile "$PROFILE" 2> /dev/null || true)
   if [ -z "$creds" ]; then
     echo "ERROR: could not export credentials for profile '$PROFILE'." >&2
     echo "       Check the profile (aws configure / aws sso login)." >&2
@@ -78,7 +95,7 @@ elif [ -n "${AWS_ACCESS_KEY_ID:-}" ] && [ -n "${AWS_SECRET_ACCESS_KEY:-}" ]; the
   AWS_SESSION_TOKEN="${AWS_SESSION_TOKEN:-}"
 else
   # Fall back to the default credential chain (default profile, role, etc.)
-  creds=$(aws configure export-credentials --format process 2>/dev/null || true)
+  creds=$(aws configure export-credentials --format process 2> /dev/null || true)
   if [ -z "$creds" ]; then
     echo "ERROR: no credentials found for signing." >&2
     echo "       Use --profile <profile>, run 'aws sso login', or set AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY." >&2
@@ -97,6 +114,6 @@ fi
 
 echo "Signed (SigV4) request to $ENDPOINT in $REGION"
 curl -4 -sS -D - "$ENDPOINT" \
-    --aws-sigv4 "aws:amz:${REGION}:vpc-lattice-svcs" \
-    --user "${AWS_ACCESS_KEY_ID}:${AWS_SECRET_ACCESS_KEY}" \
-    "${header_args[@]}"
+  --aws-sigv4 "aws:amz:${REGION}:vpc-lattice-svcs" \
+  --user "${AWS_ACCESS_KEY_ID}:${AWS_SECRET_ACCESS_KEY}" \
+  "${header_args[@]}"


### PR DESCRIPTION
## Description
**Date:** 2026-06-07 (Sunday)

Modernizes the VPC Lattice external connectivity guidance around the proxy deployment path, validation assets, and contribution tooling.

This branch replaces the older single NGINX-focused layout with a `proxies/` structure that supports both NGINX and Envoy, moves the sample testing assets under `testing/`, and updates `guidance-stack.yml` to build, seed, and deploy proxy images through CodeCommit, CodeBuild, CodePipeline, ECR, and ECS Fargate. It also adds local and CI validation so CloudFormation, Dockerfiles, shell scripts, markdown links, and proxy configs are checked consistently.

## Related issue

No linked issue.

## Type of change

- [ ] Bug fix
- [x] New feature / enhancement
- [ ] Documentation only
- [x] Proxy config / customization (NGINX or Envoy)
- [x] CI/CD or tooling

## Areas affected

- [x] Networking (VPC / PrivateLink endpoints)
- [x] Ingress (NLB / ECS Fargate proxy)
- [x] Proxy engine (`proxies/`)
- [x] CI/CD (CodePipeline / CodeBuild / CodeCommit / ECR)
- [x] Testing (`testing/`)
- [x] Documentation

## Standards checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guidelines and followed the project's standards.
- [x] I am working against the latest source on the `main` branch.
- [ ] I checked existing open and recently merged PRs to avoid duplicating work.
- [x] My change is focused on a single concern (no unrelated reformatting).

## Pre-commit / validation checklist

> These mirror the CI checks in [`.github/workflows/validation.yml`](workflows/validation.yml).
> Run them locally first: `pip install pre-commit && pre-commit install`, then `pre-commit run --all-files`.

- [x] I ran `pre-commit run --all-files` and all hooks pass.
- [x] `cfn-lint` passes (`guidance-stack.yml` and `testing/*.yml`).
- [x] `checkov` passes for the `testing/` templates.
- [x] `hadolint` passes for any changed `proxies/*/Dockerfile`.
- [x] `shellcheck` passes for any changed `*.sh` scripts.
- [ ] Proxy config validation passes for changes to `nginx.conf` / `envoy.yaml` (`nginx -t` / `envoy --mode validate`, requires Docker).
- [ ] Markdown links resolve for any changed docs.

> Note: `cfn-nag` runs in CI only (not in local pre-commit).

## Testing

- Ran `pre-commit autoupdate && pre-commit run --all-files` successfully before the latest workflow commit.
- Ran `actionlint .github/workflows/maintainer_workflows.yml .github/workflows/validation.yml` successfully while hardening the workflows.
- Verified `cfn-lint` passes with the repository `.cfnlintrc`; `E1019`, `E3014`, `E3021`, and `W1030` are documented ignores for `AWS::LanguageExtensions` false positives.
- Verified `hadolint`, `shellcheck`, `codespell`, and workflow linting through pre-commit.
- Deferred local proxy config validation because Docker was not available to this shell; the NGINX and Envoy validation scripts remain wired into CI.
- Deferred local markdown link validation to CI because the PR retains the repository's existing markdown link workflow.

## Licensing

- [x] I confirm my contribution is made under the terms of the project's [MIT-0 license](../LICENSE).

No new runtime application dependencies are introduced. New CI and local validation tools are referenced through GitHub Actions, pre-commit hooks, RubyGems, and pip for validation only.
